### PR TITLE
Add option to propagate exceptions on sync mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ With this module you can create exchanges, queues, bind this queues to his excha
 
 All will be running in singleton mode, so you will not have to worrie about multiple instances of your message queues.
 
-## Installation
+## Documentation
+
+1. [Installation](#installation)
+2. [Options](#options)
+3. [Quick examples](#quick-examples)
+
+### Installation
 
 ```bash
 # NPM
@@ -18,9 +24,33 @@ npm install --save rabbit-on-memory
 yarn add rabbit-on-memory
 ```
 
-## Examples
+### Options
 
-### Creating a queue and bind to a route on an exchange
+You can personalize some behaviours for this module using the method `setConfig()`.
+
+```typescript
+import RabbitOnMemory from 'rabbit-on-memory'
+
+// To run the subscribers methods in sync mode
+RabbitOnMemory.setConfig({
+    syncMode: true // default: false
+})
+
+// To propagate exceptions from subscribers and stop the
+// execution of the rest of them (only in sync mode)
+RabbitOnMemory.setConfig({
+    propagateExceptionsOnSyncMode: true // default: false
+})
+
+// To activate the debug mode
+RabbitOnMemory.setConfig({
+    debug: true // default: false
+})
+```
+
+### Quick examples
+
+#### Creating a queue and bind to a route on an exchange
 
 ```typescript
 import RabbitOnMemory from 'rabbit-on-memory'
@@ -39,7 +69,7 @@ RabbitOnMemory.subscribe(exchange, exchangeType, queue, bindRoute, callback})
 */
 ```
 
-### Publish message to a route and exchange
+#### Publish message to a route and exchange
 
 ```typescript
 import RabbitOnMemory from 'rabbit-on-memory'

--- a/src/interfaces/IConfigOptions.ts
+++ b/src/interfaces/IConfigOptions.ts
@@ -1,4 +1,5 @@
 export interface IConfigOptions {
   syncMode?: boolean
+  propagateExceptionsOnSyncMode?: boolean
   debug?: boolean
 }

--- a/tests/topic.spec.ts
+++ b/tests/topic.spec.ts
@@ -109,6 +109,7 @@ describe('RabbitOnMemory topic mode', () => {
     const callback2 = mockFn2
 
 
+    RabbitOnMemory.setConfig({propagateExceptionsOnSyncMode: false})
     RabbitOnMemory.subscribe(exchange1, exchangeType1, queue1, bindRoute1, callback1)
     RabbitOnMemory.subscribe(exchange2, exchangeType2, queue2, bindRoute2, callback2)
 
@@ -123,24 +124,23 @@ describe('RabbitOnMemory topic mode', () => {
     const mockFn2 = jest.fn<any, any>(() => {})
     const route = 'same.route.all'
 
-    const exchange1 = 'topic1'
+    const exchange1 = 'topic10'
     const exchangeType1 = 'topic'
-    const queue1 = 'queue1'
+    const queue1 = 'queue10'
     const bindRoute1 = route
     const callback1 = mockFn1
 
-    const exchange2 = 'topic1'
+    const exchange2 = 'topic10'
     const exchangeType2 = 'topic'
-    const queue2 = 'queue2'
+    const queue2 = 'queue20'
     const bindRoute2 = route
     const callback2 = mockFn2
 
     RabbitOnMemory.setConfig({syncMode: true, propagateExceptionsOnSyncMode: true})
-
     RabbitOnMemory.subscribe(exchange1, exchangeType1, queue1, bindRoute1, callback1)
     RabbitOnMemory.subscribe(exchange2, exchangeType2, queue2, bindRoute2, callback2)
 
-    await expect(RabbitOnMemory.publish('topic1', route, Buffer.from('Sample message'))).rejects.toThrow('test')
+    await expect(RabbitOnMemory.publish('topic10', route, Buffer.from('Sample message'))).rejects.toThrow('test')
 
     expect(mockFn1).toHaveBeenCalledTimes(1)
     expect(mockFn2).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
Sometimes is useful to stop execution when a subscriber throws an exception and we are in sync mode.

Now this is possible setting `propagateExceptionsOnSyncMode` to **true** (read the docs) 